### PR TITLE
Changing some IllegalArgumentException to MirrorException

### DIFF
--- a/src/main/java/net/vidageek/mirror/reflect/DefaultAllAnnotationsHandler.java
+++ b/src/main/java/net/vidageek/mirror/reflect/DefaultAllAnnotationsHandler.java
@@ -5,6 +5,7 @@ import java.lang.reflect.Field;
 import java.util.List;
 
 import net.vidageek.mirror.dsl.Mirror;
+import net.vidageek.mirror.exception.MirrorException;
 import net.vidageek.mirror.provider.ReflectionProvider;
 import net.vidageek.mirror.reflect.dsl.AllAnnotationsHandler;
 import net.vidageek.mirror.reflect.dsl.AllMethodAnnotationsHandler;
@@ -35,7 +36,7 @@ public final class DefaultAllAnnotationsHandler implements AllAnnotationsHandler
 	public List<Annotation> atField(final String fieldName) {
 		Field field = new Mirror(provider).on(clazz).reflect().field(fieldName);
 		if (field == null) {
-			throw new IllegalArgumentException("could not find field " + fieldName + " at class " + clazz);
+			throw new MirrorException("could not find field " + fieldName + " at class " + clazz);
 		}
 		return provider.getAnnotatedElementReflectionProvider(field).getAnnotations();
 	}

--- a/src/main/java/net/vidageek/mirror/reflect/DefaultAllMethodAnnotationsHandler.java
+++ b/src/main/java/net/vidageek/mirror/reflect/DefaultAllMethodAnnotationsHandler.java
@@ -6,6 +6,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import net.vidageek.mirror.dsl.Mirror;
+import net.vidageek.mirror.exception.MirrorException;
 import net.vidageek.mirror.provider.ReflectionProvider;
 import net.vidageek.mirror.reflect.dsl.AllMethodAnnotationsHandler;
 
@@ -43,7 +44,7 @@ public final class DefaultAllMethodAnnotationsHandler implements AllMethodAnnota
 	public List<Annotation> withArgs(final Class<?>... classes) {
 		Method method = new Mirror(provider).on(clazz).reflect().method(methodName).withArgs(classes);
 		if (method == null) {
-			throw new IllegalArgumentException("could not find method that matched " + Arrays.asList(classes));
+			throw new MirrorException("could not find method that matched " + Arrays.asList(classes));
 		}
 		return provider.getAnnotatedElementReflectionProvider(method).getAnnotations();
 	}

--- a/src/main/java/net/vidageek/mirror/reflect/DefaultMethodAnnotationHandler.java
+++ b/src/main/java/net/vidageek/mirror/reflect/DefaultMethodAnnotationHandler.java
@@ -4,6 +4,7 @@ import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 import java.util.Arrays;
 
+import net.vidageek.mirror.exception.MirrorException;
 import net.vidageek.mirror.provider.ReflectionProvider;
 import net.vidageek.mirror.reflect.dsl.MethodAnnotationHandler;
 
@@ -42,7 +43,7 @@ public final class DefaultMethodAnnotationHandler<T extends Annotation> implemen
 	public T withArgs(final Class<?>... classes) {
 		Method method = new DefaultMethodReflector(provider, methodName, clazz).withArgs(classes);
 		if (method == null) {
-			throw new IllegalArgumentException("could not find method matching argument list " + Arrays.asList(classes));
+			throw new MirrorException("could not find method matching argument list " + Arrays.asList(classes));
 		}
 		return provider.getAnnotatedElementReflectionProvider(method).getAnnotation(annotation);
 	}

--- a/src/main/java/net/vidageek/mirror/set/FieldSetterByField.java
+++ b/src/main/java/net/vidageek/mirror/set/FieldSetterByField.java
@@ -58,7 +58,7 @@ public final class FieldSetterByField implements FieldSetter {
 		if (value != null) {
 			MatchType match = new ClassArrayMatcher(value.getClass()).match(field.getType());
 			if (MatchType.DONT_MATCH.equals(match)) {
-				throw new IllegalArgumentException("Value of type " + value.getClass() + " cannot be set on field "
+				throw new MirrorException("Value of type " + value.getClass() + " cannot be set on field "
 						+ field.getName() + " of type " + field.getType() + " from class " + clazz.getName()
 						+ ". Incompatible types");
 			}

--- a/src/test/java/net/vidageek/mirror/set/FieldSetterByFieldTest.java
+++ b/src/test/java/net/vidageek/mirror/set/FieldSetterByFieldTest.java
@@ -8,6 +8,7 @@ import static org.junit.Assert.assertEquals;
 import java.lang.reflect.Field;
 
 import net.vidageek.mirror.dsl.Mirror;
+import net.vidageek.mirror.exception.MirrorException;
 import net.vidageek.mirror.fixtures.ChildFixture;
 import net.vidageek.mirror.fixtures.FieldFixture;
 import net.vidageek.mirror.fixtures.SuperClassFixture;
@@ -61,7 +62,7 @@ public class FieldSetterByFieldTest {
 		assertEquals(2, new Mirror(new DefaultMirrorReflectionProvider()).on(fixture).get().field("finalField"));
 	}
 
-	@Test(expected = IllegalArgumentException.class)
+	@Test(expected = MirrorException.class)
 	public void testThatThrowsIllegalArgumentExceptionIfValueTypeDoesntMatchFieldType() {
 
 		Field field = new Mirror(provider).on(FieldFixture.class).reflect().field("field");


### PR DESCRIPTION
Changing some `IllegalArgumentException` to `MirrorException` because validates logic and not arguments. `IllegalArgumentException` are designed to check arguments, and not results from some logic process like a when a method isn't found. Some places already uses `MirrorException`, so I changed to this exception.
