### PR TITLE
Using Java Arrays.equals to check content equality

### DIFF
--- a/src/main/java/net/vidageek/mirror/list/EqualMethodRemover.java
+++ b/src/main/java/net/vidageek/mirror/list/EqualMethodRemover.java
@@ -1,6 +1,7 @@
 package net.vidageek.mirror.list;
 
 import java.lang.reflect.Method;
+import java.util.Arrays;
 
 import net.vidageek.mirror.list.dsl.Matcher;
 
@@ -21,21 +22,10 @@ final public class EqualMethodRemover implements Matcher<Method> {
 	}
 
 	private boolean sameArgs(final Method element) {
-		if (element.getParameterTypes().length != method.getParameterTypes().length) {
-			return false;
-		}
-		int i = 0;
-		for (Class<?> type : method.getParameterTypes()) {
-			if (element.getParameterTypes()[i] != type) {
-				return false;
-			}
-			i++;
-		}
-		return true;
+		return Arrays.equals(method.getParameterTypes(), element.getParameterTypes());
 	}
 
 	private boolean sameMethodName(final Method element) {
 		return element.getName().equals(method);
 	}
-
 }


### PR DESCRIPTION
Java already have a method to check arrays equality, so we can use it. I'm using Java 8 right now, but in the Javadocs this methods exists in Java 5.

http://docs.oracle.com/javase/1.5.0/docs/api/java/util/Arrays.html#equals%28java.lang.Object[],%20java.lang.Object[]%29
