### PR TITLE
Improving collections performance adding one element per time instead of creating a new collection before elements copy

### DIFF
--- a/src/main/java/net/vidageek/mirror/bean/Bean.java
+++ b/src/main/java/net/vidageek/mirror/bean/Bean.java
@@ -1,6 +1,6 @@
 package net.vidageek.mirror.bean;
 
-import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 /**
@@ -16,10 +16,8 @@ final public class Bean {
 	}
 
 	public List<String> getter(final String fieldName) {
-		List<String> list = new ArrayList<String>();
-		list.add("get" + capitalize(fieldName));
-		list.add("is" + capitalize(fieldName));
-		return list;
+		String capitalized = capitalize(fieldName);
+		return Arrays.asList("get" + capitalized, "is" + capitalized);
 	}
 
 	public String setter(final String fieldName) {

--- a/src/main/java/net/vidageek/mirror/provider/java/PureJavaClassReflectionProvider.java
+++ b/src/main/java/net/vidageek/mirror/provider/java/PureJavaClassReflectionProvider.java
@@ -39,25 +39,32 @@ public final class PureJavaClassReflectionProvider<T> implements ClassReflection
 	}
 
 	public List<Field> reflectAllFields() {
-		Class<?> c = clazz;
 		final List<Field> list = new ArrayList<Field>();
-		while (c != null) {
-			list.addAll(Arrays.asList(c.getDeclaredFields()));
-			for (Class<?> interf : c.getInterfaces()) {
-				list.addAll(Arrays.asList(interf.getFields()));
+
+		for (Class<?> current = clazz; current != null; current = current.getSuperclass()) {
+			for (Field field : current.getDeclaredFields()) {
+				list.add(field);
 			}
-			c = c.getSuperclass();
+
+			for (Class<?> interf : current.getInterfaces()) {
+				for (Field field : interf.getDeclaredFields()) {
+					list.add(field);
+				}
+			}
 		}
+
 		return list;
 	}
 
 	public List<Method> reflectAllMethods() {
-		Class<?> c = clazz;
 		final List<Method> list = new ArrayList<Method>();
-		while (c != null) {
-			list.addAll(Arrays.asList(c.getDeclaredMethods()));
-			c = c.getSuperclass();
+
+		for (Class<?> current = clazz; current != null; current = current.getSuperclass()) {
+			for (Method method : current.getDeclaredMethods()) {
+				list.add(method);
+			}
 		}
+
 		return list;
 	}
 


### PR DESCRIPTION
There are some small improvement for big applications with many requests. Instead of create an initial `ArrayList` and another `ArrayList` with elements to use `List.addAll` I create only one `ArrayList` and add each element per time.
