### PR TITLE
Applying copyright owner. Closes #56

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -187,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
+   Copyright 2008 Jonas Abreu
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/LICENSE
+++ b/LICENSE
@@ -187,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2008 Jonas Abreu
+   Copyright 2008 Jonas Abreu and Mirror's contributors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.


### PR DESCRIPTION
As described in APL license guide, the text `Copyright [yyyy] [name of copyright owner]` needs to be replaced with copyright owner and the date of 1st release under this license.

The properly license terms its important to allow other users to use Mirror in their projects.
